### PR TITLE
[next-adapter] bump next.js to ^12

### DIFF
--- a/packages/next-adapter/package.json
+++ b/packages/next-adapter/package.json
@@ -48,7 +48,7 @@
     "@types/prompts": "^2.0.6"
   },
   "peerDependencies": {
-    "next": "^11",
+    "next": "^12",
     "react": "^17",
     "react-native-web": "^0.17.0"
   },


### PR DESCRIPTION
I haven't tested this (yet, just about to build depending on this fork), but I assume the adapter works on next v12, sans https://github.com/expo/expo/issues/14971
